### PR TITLE
Fix execution of unit tests with Maven

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#10](https://github.com/green-code-initiative/ecoCode-php/pull/10) Adding EC35 rule : EC35 rule replaces EC34 with a specific use case ("file not found" specific)
 - [#13](https://github.com/green-code-initiative/ecoCode-php/issues/13) Add build number to manifest
 - Update ecocode-rules-specifications to 0.0.9
-- Fix unit tests execution with Maven
+- [#12](https://github.com/green-code-initiative/ecoCode-php/issues/12) Fix unit tests execution with Maven
 
 ### Deleted
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#10](https://github.com/green-code-initiative/ecoCode-php/pull/10) Adding EC35 rule : EC35 rule replaces EC34 with a specific use case ("file not found" specific)
 - [#13](https://github.com/green-code-initiative/ecoCode-php/issues/13) Add build number to manifest
 - Update ecocode-rules-specifications to 0.0.9
+- Fix unit tests execution with Maven
 
 ### Deleted
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,16 +5,19 @@
     <groupId>io.ecocode</groupId>
     <artifactId>ecocode-php-plugin</artifactId>
     <version>1.4.1-SNAPSHOT</version>
+
     <packaging>sonar-plugin</packaging>
 
     <name>ecoCode - PHP language</name>
     <description>Provides rules to reduce the environmental footprint of your PHP programs</description>
     <inceptionYear>2023</inceptionYear>
+
     <url>https://github.com/green-code-initiative/ecoCode-php</url>
     <organization>
         <name>green-code-initiative</name>
         <url>https://github.com/green-code-initiative</url>
     </organization>
+
     <licenses>
         <license>
             <name>GPL v3</name>
@@ -22,12 +25,14 @@
             <distribution>repo</distribution>
         </license>
     </licenses>
+
     <scm>
         <connection>scm:git:https://github.com/green-code-initiative/ecocode-php</connection>
         <developerConnection>scm:git:https://github.com/green-code-initiative/ecocode-php</developerConnection>
         <url>https://github.com/green-code-initiative/ecocode-php</url>
         <tag>HEAD</tag>
     </scm>
+
     <issueManagement>
         <system>GitHub</system>
         <url>https://github.com/green-code-initiative/ecoCode-php/issues</url>
@@ -52,20 +57,18 @@
         <!-- max version with SonarQube 10.0 : check lib/extension directory -->
         <sonarphp.version>3.28.0.9490</sonarphp.version>
 
-        <!-- max version with SonarQube 10.0 : check lib/extension directory -->
-        <sonarjava.version>7.17.0.31219</sonarjava.version>
-
+        <sonar-analyzer-commons.version>2.5.0.1358</sonar-analyzer-commons.version>
         <sonar-packaging.version>1.23.0.740</sonar-packaging.version>
-        <sonar.skipDependenciesPackaging>true</sonar.skipDependenciesPackaging>
-
-        <junit.jupiter.version>5.9.1</junit.jupiter.version>
-        <assertJ.version>3.23.1</assertJ.version>
-        <mockito.version>5.3.1</mockito.version>
 
         <!-- temporary version waiting for real automatic release in ecocode repository -->
         <ecocode-rules-specifications.version>0.0.9</ecocode-rules-specifications.version>
 
-        <sonar-analyzer-commons.version>2.5.0.1358</sonar-analyzer-commons.version>
+        <maven-shade.version>3.5.0</maven-shade.version>
+
+        <junit.jupiter.version>5.9.2</junit.jupiter.version>
+        <assertj.version>3.24.2</assertj.version>
+        <mockito.version>5.3.1</mockito.version>
+        <jacoco.version>0.8.11</jacoco.version>
 
     </properties>
 
@@ -102,13 +105,6 @@
 
         <!-- TEST sources dependencies -->
         <dependency>
-            <groupId>org.sonarsource.java</groupId>
-            <artifactId>java-checks-testkit</artifactId>
-            <version>${sonarjava.version}</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <version>${junit.jupiter.version}</version>
@@ -118,7 +114,7 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>${assertJ.version}</version>
+            <version>${assertj.version}</version>
             <scope>test</scope>
         </dependency>
 
@@ -172,11 +168,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.10</version>
-                <configuration>
-                    <output>file</output>
-                    <append>false</append>
-                </configuration>
+                <version>${jacoco.version}</version>
                 <executions>
                     <execution>
                         <id>prepare-agent</id>
@@ -203,6 +195,7 @@
                     <pluginClass>fr.greencodeinitiative.php.PHPPlugin</pluginClass>
                     <sonarLintSupported>true</sonarLintSupported>
                     <pluginApiMinVersion>${sonarqube.version}</pluginApiMinVersion>
+                    <skipDependenciesPackaging>true</skipDependenciesPackaging>
                     <jreMinVersion>${java.version}</jreMinVersion>
                     <archive>
                         <manifestEntries>
@@ -233,8 +226,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.5.0</version>
-                <!-- common configuration for shade plugin -->
+                <version>${maven-shade.version}</version>
                 <executions>
                     <execution>
                         <phase>package</phase>
@@ -242,29 +234,19 @@
                             <goal>shade</goal>
                         </goals>
                         <configuration>
+                            <shadedArtifactAttached>false</shadedArtifactAttached>
+                            <minimizeJar>true</minimizeJar>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
                             <filters>
-                                <filter>
-                                    <artifact>commons-*:*</artifact>
-                                    <excludes>
-                                        <exclude>META-INF/**</exclude>
-                                    </excludes>
-                                </filter>
                                 <filter>
                                     <artifact>org.*:*</artifact>
                                     <excludes>
                                         <exclude>META-INF/**</exclude>
-                                        <exclude>org/sonar/api/batch/sensor/**</exclude>
                                         <exclude>javax/annotation/**</exclude>
                                     </excludes>
                                 </filter>
                                 <filter>
-                                    <artifact>com.*:*</artifact>
-                                    <excludes>
-                                        <exclude>META-INF/**</exclude>
-                                    </excludes>
-                                </filter>
-                                <filter>
-                                    <artifact>junit:*</artifact>
+                                    <artifact>io.ecocode:ecocode-rules-specifications:*</artifact>
                                     <excludes>
                                         <exclude>META-INF/**</exclude>
                                     </excludes>

--- a/src/test/java/fr/greencodeinitiative/php/checks/AvoidDoubleQuoteCheckTest.java
+++ b/src/test/java/fr/greencodeinitiative/php/checks/AvoidDoubleQuoteCheckTest.java
@@ -17,11 +17,11 @@
  */
 package fr.greencodeinitiative.php.checks;
 
-import java.io.File;
-
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.sonar.plugins.php.api.tests.PHPCheckTest;
 import org.sonar.plugins.php.api.tests.PhpTestFile;
+
+import java.io.File;
 
 public class AvoidDoubleQuoteCheckTest {
 

--- a/src/test/java/fr/greencodeinitiative/php/checks/AvoidDoubleQuoteCheckTest.java
+++ b/src/test/java/fr/greencodeinitiative/php/checks/AvoidDoubleQuoteCheckTest.java
@@ -23,10 +23,10 @@ import org.sonar.plugins.php.api.tests.PhpTestFile;
 
 import java.io.File;
 
-public class AvoidDoubleQuoteCheckTest {
+class AvoidDoubleQuoteCheckTest {
 
     @Test
-    public void test() throws Exception {
+    void test() throws Exception {
         PHPCheckTest.check(new AvoidDoubleQuoteCheck(), new PhpTestFile(new File("src/test/resources/checks/AvoidDoubleQuote.php")));
     }
 

--- a/src/test/java/fr/greencodeinitiative/php/checks/AvoidFullSQLRequestCheckTest.java
+++ b/src/test/java/fr/greencodeinitiative/php/checks/AvoidFullSQLRequestCheckTest.java
@@ -23,10 +23,10 @@ import org.sonar.plugins.php.api.tests.PhpTestFile;
 
 import java.io.File;
 
-public class AvoidFullSQLRequestCheckTest {
+class AvoidFullSQLRequestCheckTest {
 
     @Test
-    public void test() {
+    void test() {
         PHPCheckTest.check(new AvoidFullSQLRequestCheck(), new PhpTestFile(new File("src/test/resources/checks/AvoidFullSQLRequest.php")));
     }
 

--- a/src/test/java/fr/greencodeinitiative/php/checks/AvoidFullSQLRequestCheckTest.java
+++ b/src/test/java/fr/greencodeinitiative/php/checks/AvoidFullSQLRequestCheckTest.java
@@ -17,11 +17,11 @@
  */
 package fr.greencodeinitiative.php.checks;
 
-import java.io.File;
-
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.sonar.plugins.php.api.tests.PHPCheckTest;
 import org.sonar.plugins.php.api.tests.PhpTestFile;
+
+import java.io.File;
 
 public class AvoidFullSQLRequestCheckTest {
 
@@ -29,4 +29,5 @@ public class AvoidFullSQLRequestCheckTest {
     public void test() {
         PHPCheckTest.check(new AvoidFullSQLRequestCheck(), new PhpTestFile(new File("src/test/resources/checks/AvoidFullSQLRequest.php")));
     }
+
 }

--- a/src/test/java/fr/greencodeinitiative/php/checks/AvoidGettingSizeCollectionInLoopTest.java
+++ b/src/test/java/fr/greencodeinitiative/php/checks/AvoidGettingSizeCollectionInLoopTest.java
@@ -23,10 +23,10 @@ import org.sonar.plugins.php.api.tests.PhpTestFile;
 
 import java.io.File;
 
-public class AvoidGettingSizeCollectionInLoopTest {
+class AvoidGettingSizeCollectionInLoopTest {
 
     @Test
-    public void test() throws Exception {
+    void test() throws Exception {
         PHPCheckTest.check(new AvoidGettingSizeCollectionInLoopCheck(), new PhpTestFile(new File("src/test/resources/checks/AvoidGettingSizeCollectionInLoop.php")));
     }
 

--- a/src/test/java/fr/greencodeinitiative/php/checks/AvoidGettingSizeCollectionInLoopTest.java
+++ b/src/test/java/fr/greencodeinitiative/php/checks/AvoidGettingSizeCollectionInLoopTest.java
@@ -17,7 +17,7 @@
  */
 package fr.greencodeinitiative.php.checks;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.sonar.plugins.php.api.tests.PHPCheckTest;
 import org.sonar.plugins.php.api.tests.PhpTestFile;
 
@@ -29,4 +29,5 @@ public class AvoidGettingSizeCollectionInLoopTest {
     public void test() throws Exception {
         PHPCheckTest.check(new AvoidGettingSizeCollectionInLoopCheck(), new PhpTestFile(new File("src/test/resources/checks/AvoidGettingSizeCollectionInLoop.php")));
     }
+
 }

--- a/src/test/java/fr/greencodeinitiative/php/checks/AvoidMultipleIfElseStatementCheckTest.java
+++ b/src/test/java/fr/greencodeinitiative/php/checks/AvoidMultipleIfElseStatementCheckTest.java
@@ -17,15 +17,12 @@
  */
 package fr.greencodeinitiative.php.checks;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.sonar.plugins.php.api.tests.PHPCheckTest;
 import org.sonar.plugins.php.api.tests.PhpTestFile;
 
 import java.io.File;
 
-/**
- * Test class to test the check implementation.
- */
 public class AvoidMultipleIfElseStatementCheckTest {
 
     @Test

--- a/src/test/java/fr/greencodeinitiative/php/checks/AvoidMultipleIfElseStatementCheckTest.java
+++ b/src/test/java/fr/greencodeinitiative/php/checks/AvoidMultipleIfElseStatementCheckTest.java
@@ -23,10 +23,10 @@ import org.sonar.plugins.php.api.tests.PhpTestFile;
 
 import java.io.File;
 
-public class AvoidMultipleIfElseStatementCheckTest {
+class AvoidMultipleIfElseStatementCheckTest {
 
     @Test
-    public void test() throws Exception {
+    void test() throws Exception {
         PHPCheckTest.check(new AvoidMultipleIfElseStatementCheck(), new PhpTestFile(new File("src/test/resources/checks/AvoidMultipleIfElseStatement.php")));
     }
 

--- a/src/test/java/fr/greencodeinitiative/php/checks/AvoidSQLRequestInLoopCheckTest.java
+++ b/src/test/java/fr/greencodeinitiative/php/checks/AvoidSQLRequestInLoopCheckTest.java
@@ -23,10 +23,10 @@ import org.sonar.plugins.php.api.tests.PhpTestFile;
 
 import java.io.File;
 
-public class AvoidSQLRequestInLoopCheckTest {
+class AvoidSQLRequestInLoopCheckTest {
 
     @Test
-    public void test() throws Exception {
+    void test() throws Exception {
         PHPCheckTest.check(new AvoidSQLRequestInLoopCheck(), new PhpTestFile(new File("src/test/resources/checks/AvoidSQLRequestInLoop.php")));
     }
 

--- a/src/test/java/fr/greencodeinitiative/php/checks/AvoidSQLRequestInLoopCheckTest.java
+++ b/src/test/java/fr/greencodeinitiative/php/checks/AvoidSQLRequestInLoopCheckTest.java
@@ -17,11 +17,11 @@
  */
 package fr.greencodeinitiative.php.checks;
 
-import java.io.File;
-
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.sonar.plugins.php.api.tests.PHPCheckTest;
 import org.sonar.plugins.php.api.tests.PhpTestFile;
+
+import java.io.File;
 
 public class AvoidSQLRequestInLoopCheckTest {
 
@@ -29,4 +29,5 @@ public class AvoidSQLRequestInLoopCheckTest {
     public void test() throws Exception {
         PHPCheckTest.check(new AvoidSQLRequestInLoopCheck(), new PhpTestFile(new File("src/test/resources/checks/AvoidSQLRequestInLoop.php")));
     }
+
 }

--- a/src/test/java/fr/greencodeinitiative/php/checks/AvoidTryCatchWithFileOpenedCheckTest.java
+++ b/src/test/java/fr/greencodeinitiative/php/checks/AvoidTryCatchWithFileOpenedCheckTest.java
@@ -23,10 +23,10 @@ import org.sonar.plugins.php.api.tests.PhpTestFile;
 
 import java.io.File;
 
-public class AvoidTryCatchWithFileOpenedCheckTest {
+class AvoidTryCatchWithFileOpenedCheckTest {
 
     @Test
-    public void test() throws Exception {
+    void test() throws Exception {
         PHPCheckTest.check(new AvoidTryCatchWithFileOpenedCheck(), new PhpTestFile(new File("src/test/resources/checks/AvoidTryCatchWithFileOpenedCheck.php")));
     }
 

--- a/src/test/java/fr/greencodeinitiative/php/checks/AvoidTryCatchWithFileOpenedCheckTest.java
+++ b/src/test/java/fr/greencodeinitiative/php/checks/AvoidTryCatchWithFileOpenedCheckTest.java
@@ -17,11 +17,11 @@
  */
 package fr.greencodeinitiative.php.checks;
 
-import java.io.File;
-
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.sonar.plugins.php.api.tests.PHPCheckTest;
 import org.sonar.plugins.php.api.tests.PhpTestFile;
+
+import java.io.File;
 
 public class AvoidTryCatchWithFileOpenedCheckTest {
 

--- a/src/test/java/fr/greencodeinitiative/php/checks/AvoidUsingGlobalVariablesCheckTest.java
+++ b/src/test/java/fr/greencodeinitiative/php/checks/AvoidUsingGlobalVariablesCheckTest.java
@@ -23,10 +23,10 @@ import org.sonar.plugins.php.api.tests.PhpTestFile;
 
 import java.io.File;
 
-public class AvoidUsingGlobalVariablesCheckTest {
+class AvoidUsingGlobalVariablesCheckTest {
 
     @Test
-    public void test() throws Exception {
+    void test() throws Exception {
         PHPCheckTest.check(new AvoidUsingGlobalVariablesCheck(), new PhpTestFile(new File("src/test/resources/checks/AvoidUsingGlobalVariablesCheck.php")));
     }
 

--- a/src/test/java/fr/greencodeinitiative/php/checks/AvoidUsingGlobalVariablesCheckTest.java
+++ b/src/test/java/fr/greencodeinitiative/php/checks/AvoidUsingGlobalVariablesCheckTest.java
@@ -17,7 +17,7 @@
  */
 package fr.greencodeinitiative.php.checks;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.sonar.plugins.php.api.tests.PHPCheckTest;
 import org.sonar.plugins.php.api.tests.PhpTestFile;
 

--- a/src/test/java/fr/greencodeinitiative/php/checks/IncrementCheckTest.java
+++ b/src/test/java/fr/greencodeinitiative/php/checks/IncrementCheckTest.java
@@ -17,11 +17,11 @@
  */
 package fr.greencodeinitiative.php.checks;
 
-import java.io.File;
-
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.sonar.plugins.php.api.tests.PHPCheckTest;
 import org.sonar.plugins.php.api.tests.PhpTestFile;
+
+import java.io.File;
 
 public class IncrementCheckTest {
 

--- a/src/test/java/fr/greencodeinitiative/php/checks/IncrementCheckTest.java
+++ b/src/test/java/fr/greencodeinitiative/php/checks/IncrementCheckTest.java
@@ -23,10 +23,10 @@ import org.sonar.plugins.php.api.tests.PhpTestFile;
 
 import java.io.File;
 
-public class IncrementCheckTest {
+class IncrementCheckTest {
 
     @Test
-    public void test() throws Exception {
+    void test() throws Exception {
         PHPCheckTest.check(new IncrementCheck(), new PhpTestFile(new File("src/test/resources/checks/IncrementCheck.php")));
     }
 

--- a/src/test/java/fr/greencodeinitiative/php/checks/NoFunctionCallWhenDeclaringForLoopTest.java
+++ b/src/test/java/fr/greencodeinitiative/php/checks/NoFunctionCallWhenDeclaringForLoopTest.java
@@ -17,11 +17,11 @@
  */
 package fr.greencodeinitiative.php.checks;
 
-import java.io.File;
-
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.sonar.plugins.php.api.tests.PHPCheckTest;
 import org.sonar.plugins.php.api.tests.PhpTestFile;
+
+import java.io.File;
 
 public class NoFunctionCallWhenDeclaringForLoopTest {
 
@@ -29,4 +29,5 @@ public class NoFunctionCallWhenDeclaringForLoopTest {
     public void test() throws Exception {
         PHPCheckTest.check(new NoFunctionCallWhenDeclaringForLoop(), new PhpTestFile(new File("src/test/resources/checks/NoFunctionCallWhenDeclaringForLoop.php")));
     }
+
 }

--- a/src/test/java/fr/greencodeinitiative/php/checks/NoFunctionCallWhenDeclaringForLoopTest.java
+++ b/src/test/java/fr/greencodeinitiative/php/checks/NoFunctionCallWhenDeclaringForLoopTest.java
@@ -23,10 +23,10 @@ import org.sonar.plugins.php.api.tests.PhpTestFile;
 
 import java.io.File;
 
-public class NoFunctionCallWhenDeclaringForLoopTest {
+class NoFunctionCallWhenDeclaringForLoopTest {
 
     @Test
-    public void test() throws Exception {
+    void test() throws Exception {
         PHPCheckTest.check(new NoFunctionCallWhenDeclaringForLoop(), new PhpTestFile(new File("src/test/resources/checks/NoFunctionCallWhenDeclaringForLoop.php")));
     }
 

--- a/src/test/java/fr/greencodeinitiative/php/checks/UseOfMethodsForBasicOperationsTest.java
+++ b/src/test/java/fr/greencodeinitiative/php/checks/UseOfMethodsForBasicOperationsTest.java
@@ -23,10 +23,10 @@ import org.sonar.plugins.php.api.tests.PhpTestFile;
 
 import java.io.File;
 
-public class UseOfMethodsForBasicOperationsTest {
+class UseOfMethodsForBasicOperationsTest {
 
     @Test
-    public void test() throws Exception {
+    void test() throws Exception {
         PHPCheckTest.check(new UseOfMethodsForBasicOperations(), new PhpTestFile(new File("src/test/resources/checks/UseOfMethodsForBasicOperations.php")));
     }
 

--- a/src/test/java/fr/greencodeinitiative/php/checks/UseOfMethodsForBasicOperationsTest.java
+++ b/src/test/java/fr/greencodeinitiative/php/checks/UseOfMethodsForBasicOperationsTest.java
@@ -17,11 +17,11 @@
  */
 package fr.greencodeinitiative.php.checks;
 
-import java.io.File;
-
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.sonar.plugins.php.api.tests.PHPCheckTest;
 import org.sonar.plugins.php.api.tests.PhpTestFile;
+
+import java.io.File;
 
 public class UseOfMethodsForBasicOperationsTest {
 
@@ -29,4 +29,5 @@ public class UseOfMethodsForBasicOperationsTest {
     public void test() throws Exception {
         PHPCheckTest.check(new UseOfMethodsForBasicOperations(), new PhpTestFile(new File("src/test/resources/checks/UseOfMethodsForBasicOperations.php")));
     }
+
 }


### PR DESCRIPTION
As discussed in #10 and #12, there is an issue with the coverage of this plugin. In fact, the problem is that some tests aren't run via Maven: they haven't been migrated to JUnit 5 (Jupiter). What's surprising is that Intellij doesn't complain about it, so it wasn't easy to spot. So, what I have done in this PR:

- Import `org.junit.jupiter.api.Test` (JUnit 5) instead of `org.junit.test` (JUnit 4) in test files
- Optimize shaded jar (based on what I have done in ecoCode-javascript, jar is now 87ko instead of 132ko)
- Upgrade few testing dependencies

Tests are OK on my local SonarQube.
Resolves #12 